### PR TITLE
Add contains() method to Preferences module

### DIFF
--- a/library/src/androidTest/java/chipset/potato/tests/MethodTest.java
+++ b/library/src/androidTest/java/chipset/potato/tests/MethodTest.java
@@ -85,6 +85,8 @@ public class MethodTest extends AndroidTestCase {
         assertFalse(preferences.getSharedPreferenceBoolean("boolean"));
         assertEquals((long) 0, preferences.getSharedPreferenceLong("long"));
         assertEquals(0.0f, preferences.getSharedPreferenceFloat("float"));
+        assertEquals(preferences.sharedPreferenceExists("String"), true);
+        assertEquals(preferences.sharedPreferenceExists("NoString"), false);
     }
 
     public void testForIntentsMethods() {

--- a/library/src/main/java/chipset/potato/preferences/Preferences.java
+++ b/library/src/main/java/chipset/potato/preferences/Preferences.java
@@ -173,4 +173,16 @@ public class Preferences {
         // mode
         pref.edit().remove(preferenceName).commit();
     }
+
+    /**
+     * Method to check whether a preference key has been created
+     *
+     * @param preferenceName Name of the preference
+     */
+    public boolean sharedPreferenceExists(String preferenceName){
+        SharedPreferences pref = mContext
+                .getSharedPreferences(preferenceName, 0);
+
+        return pref.contains(preferenceName);
+    }
 }


### PR DESCRIPTION
Closes issue #5 

Adds the `sharedPreferenceExists()` method to the Preferences class. This method enables the user to check whether a shared preference with the same key exists or not.

I've also added the corresponding tests.
